### PR TITLE
Switch backend address geocoding to Google Maps API

### DIFF
--- a/api/supabase/db_api.py
+++ b/api/supabase/db_api.py
@@ -260,42 +260,59 @@ class PropertyUpdate(BaseModel):
     zip_code: str | None = None
 
 
-GEOCODE_MAPS_CO_SEARCH_URL = "https://geocode.maps.co/search"
+GOOGLE_GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
 
 
 async def _geocode_address(address: str) -> tuple[float, float]:
-    api_key = os.getenv("GEOCODE_API_KEY")
+    api_key = os.getenv("GOOGLE_MAPS_API_KEY")
     if not api_key:
-        raise HTTPException(status_code=500, detail="GEOCODE_API_KEY is not configured")
+        raise HTTPException(status_code=500, detail="GOOGLE_MAPS_API_KEY is not configured")
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
-                GEOCODE_MAPS_CO_SEARCH_URL,
-                params={"q": address, "api_key": api_key},
+                GOOGLE_GEOCODE_URL,
+                params={"address": address, "key": api_key},
             )
             response.raise_for_status()
             geocode_result = response.json()
     except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail=f"geocode.maps.co request failed: {exc}")
+        raise HTTPException(status_code=502, detail=f"Google Geocoding request failed: {exc}")
 
-    if not isinstance(geocode_result, list) or not geocode_result:
+    status = geocode_result.get("status")
+    if status != "OK":
+        if status == "ZERO_RESULTS":
+            raise HTTPException(status_code=404, detail="No matching address found")
+        error_message = geocode_result.get("error_message")
+        details = f"{status}: {error_message}" if error_message else str(status)
+        raise HTTPException(status_code=502, detail=f"Google Geocoding error: {details}")
+
+    results = geocode_result.get("results")
+    if not isinstance(results, list) or not results:
         raise HTTPException(status_code=404, detail="No matching address found")
 
-    result = geocode_result[0]
+    result = results[0]
     if not isinstance(result, dict):
-        raise HTTPException(status_code=502, detail="Unable to parse geocode.maps.co response")
+        raise HTTPException(status_code=502, detail="Unable to parse Google Geocoding response")
 
-    lat_raw = result.get("lat")
-    lng_raw = result.get("lon")
+    geometry = result.get("geometry")
+    if not isinstance(geometry, dict):
+        raise HTTPException(status_code=502, detail="Unable to parse Google Geocoding response")
+
+    location = geometry.get("location")
+    if not isinstance(location, dict):
+        raise HTTPException(status_code=502, detail="Unable to parse Google Geocoding coordinates")
+
+    lat_raw = location.get("lat")
+    lng_raw = location.get("lng")
     if lat_raw is None or lng_raw is None:
-        raise HTTPException(status_code=502, detail="Unable to parse geocode.maps.co coordinates")
+        raise HTTPException(status_code=502, detail="Unable to parse Google Geocoding coordinates")
 
     try:
         lat = float(lat_raw)
         lng = float(lng_raw)
     except (TypeError, ValueError):
-        raise HTTPException(status_code=502, detail="Unable to parse geocode.maps.co coordinates")
+        raise HTTPException(status_code=502, detail="Unable to parse Google Geocoding coordinates")
 
     return lat, lng
 


### PR DESCRIPTION
### Motivation
- Consolidate geocoding to Google's API since Google APIs are already used elsewhere, and use the existing `GOOGLE_MAPS_API_KEY` for address -> lat/lng lookups.
- Handle Google Geocoding response shapes and statuses explicitly to avoid mis-parsing responses from the previous provider.

### Description
- Replaced `geocode.maps.co` usage with the Google Geocoding endpoint by introducing `GOOGLE_GEOCODE_URL` and updating the request in `api/supabase/db_api.py`.
- Switched environment key lookup from `GEOCODE_API_KEY` to `GOOGLE_MAPS_API_KEY` and updated request params to `address`/`key`.
- Updated response parsing to use `status`, `results[0].geometry.location.lat` and `.lng`, and added checks for `ZERO_RESULTS` vs other Google errors with clearer error messages.
- Adjusted error messages and parsing guards to report Google-specific parsing and request failures.

### Testing
- Ran `python -m compileall api/supabase/db_api.py`, which succeeded and confirmed the module compiles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9adf67308329b77ff4a8519e7bdf)